### PR TITLE
Add stats for SotA/IoC and improve stat display

### DIFF
--- a/stat.lua
+++ b/stat.lua
@@ -29,9 +29,9 @@ f:SetBackdrop({
     insets = { left = 4, right = 4, top = 4, bottom = 4 },    
 })
 -- f:SetBackdropColor(0, 0, 0)
-f:SetPoint("TOPLEFT", HonorFrame or PVPFrame, "TOPRIGHT" , -30, -15)
-f:SetWidth(260)
-f:SetHeight((30 + panelheight + 10) * (BattleZoneHelper.IsBCC and 4 or 3))
+f:SetPoint("TOPLEFT", HonorFrame or PVPFrame, "TOPRIGHT" , -30, -12)
+f:SetWidth(495)
+f:SetHeight((30 + panelheight + 10) * (BattleZoneHelper.IsBCC and 4 or 3) + 7)
 
 local loc = 30 + panelheight
 local function nextloc()
@@ -45,14 +45,17 @@ end
 
 local labels = {}
 
-local function DrawStat(bgid)
-
+local function DrawStat(bgid, i)
     local p = CreateFrame("Frame", nil, f, BackdropTemplateMixin and "BackdropTemplate" or nil)
     p:SetBackdrop({ 
         edgeFile = "Interface\\DialogFrame\\UI-DialogBox-Border",
         edgeSize = 16,
-    })    
-    p:SetPoint("TOPLEFT", f, 15, -15 + nextloc())
+    })
+    local columnOffset = 235 * math.floor(i / 3)
+    if i % 3 == 0 then
+        loc = 30 + panelheight  -- start new column at the top
+    end
+    p:SetPoint("TOPLEFT", f, 15 + columnOffset, -15 + nextloc())
     p:SetWidth(230)
     p:SetHeight(30 + panelheight + 10)
 
@@ -202,12 +205,14 @@ end)
 RegEvent("ADDON_LOADED", function()
     BatteInfoStat = BatteInfoStat or {}
 
+    local i = 0
     for _, id in pairs(BattleZoneHelper.MAPNAME_BGID_MAP) do
         BatteInfoStat[id] = BatteInfoStat[id] or {
             start = time(),
         }
 
-        DrawStat(id)
+        DrawStat(id, i)
+        i = i + 1
     end
 
     UpdateStatLabels()

--- a/utils.lua
+++ b/utils.lua
@@ -27,18 +27,27 @@ BattleZoneHelper.MAPNAME_ARATHI = C_Map.GetMapInfo(BattleZoneHelper.MAPID_ARATHI
 BattleZoneHelper.MAPID_STORM = 1956
 BattleZoneHelper.MAPNAME_STORM = C_Map.GetMapInfo(BattleZoneHelper.MAPID_STORM).name
 
--- ( 1 for Alterac Valley, 2 for Warsong Gulch, 3 for Arathi Basin, 4 for Eye of the Storm
+BattleZoneHelper.MAPID_STRAND = 128
+BattleZoneHelper.MAPNAME_STRAND = C_Map.GetMapInfo(BattleZoneHelper.MAPID_STRAND).name
+
+BattleZoneHelper.MAPID_CONQUEST = 169
+BattleZoneHelper.MAPNAME_CONQUEST = C_Map.GetMapInfo(BattleZoneHelper.MAPID_CONQUEST).name
+
+-- ( 1 for Alterac Valley, 2 for Warsong Gulch, 3 for Arathi Basin, 4 for Eye of the Storm, 5 for Strand of the Ancients, 6 for Isle of Conquest
 BattleZoneHelper.BGID_ALTERAC = 1
 BattleZoneHelper.BGID_WARSONG = 2
 BattleZoneHelper.BGID_ARATHI = 3
 BattleZoneHelper.BGID_STORM = 4
-
+BattleZoneHelper.BGID_STRAND = 5
+BattleZoneHelper.BGID_CONQUEST = 6
 
 BattleZoneHelper.BGID_MAPNAME_MAP = {
     [BattleZoneHelper.BGID_ALTERAC] = BattleZoneHelper.MAPNAME_ALTERAC,
     [BattleZoneHelper.BGID_WARSONG] = BattleZoneHelper.MAPNAME_WARSONG, 
     [BattleZoneHelper.BGID_ARATHI]  = BattleZoneHelper.MAPNAME_ARATHI,
     [BattleZoneHelper.BGID_STORM] = BattleZoneHelper.MAPNAME_STORM,
+    [BattleZoneHelper.BGID_STRAND] = BattleZoneHelper.MAPNAME_STRAND,
+    [BattleZoneHelper.BGID_CONQUEST] = BattleZoneHelper.MAPNAME_CONQUEST,
 }
 
 BattleZoneHelper.MAPNAME_BGID_MAP = {
@@ -46,6 +55,8 @@ BattleZoneHelper.MAPNAME_BGID_MAP = {
     [BattleZoneHelper.MAPNAME_WARSONG] = BattleZoneHelper.BGID_WARSONG,
     [BattleZoneHelper.MAPNAME_ARATHI]  = BattleZoneHelper.BGID_ARATHI,
     [BattleZoneHelper.MAPNAME_STORM] = BattleZoneHelper.BGID_STORM,
+    [BattleZoneHelper.MAPNAME_STRAND] = BattleZoneHelper.BGID_STRAND,
+    [BattleZoneHelper.MAPNAME_CONQUEST] = BattleZoneHelper.BGID_CONQUEST,
 }
 
 ADDONSELF.InBattleground = function()


### PR DESCRIPTION
Fixes a couple of issues:

* Stats aren't tracked for the battlegrounds introduced in Wrath of the Lich King (Classic) - Strand of the Ancients and Isle of Conquest.
* Stat display isn't clean (stats for the fourth BG don't fit inside the stat pane)